### PR TITLE
Correct operation name fallback mechanism in ClusterClient.

### DIFF
--- a/Vostok.ClusterClient/Modules/OperationNameFallbackModule.cs
+++ b/Vostok.ClusterClient/Modules/OperationNameFallbackModule.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using Vostok.Clusterclient.Model;
+using Vostok.Commons.Extensions.Uri;
+using Vostok.Flow;
+using Vostok.Tracing;
+
+namespace Vostok.Clusterclient.Modules
+{
+    internal class OperationNameFallbackModule : IRequestModule
+    {
+        public Task<ClusterResult> ExecuteAsync(IRequestContext context, Func<IRequestContext, Task<ClusterResult>> next)
+        {
+            if (Context.Properties.Current.ContainsKey(TracingAnnotationNames.Operation))
+            {
+                return next(context);
+            }
+
+            return ExecuteInternal(context, next);
+        }
+
+        private static async Task<ClusterResult> ExecuteInternal(IRequestContext context, Func<IRequestContext, Task<ClusterResult>> next)
+        {
+            var operationName = context.Request.Method + " " + context.Request.Url.GetNormalizedPath();
+            
+            using (Context.Properties.Use(TracingAnnotationNames.Operation, operationName))
+            {
+                return await next(context).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Vostok.ClusterClient/Modules/RequestModuleChainBuilder.cs
+++ b/Vostok.ClusterClient/Modules/RequestModuleChainBuilder.cs
@@ -18,10 +18,11 @@ namespace Vostok.Clusterclient.Modules
             var requestSender = new RequestSender(config, storageProvider, responseClassifier, requestConverter, config.Transport);
             var resultStatusSelector = new ClusterResultStatusSelector();
 
-            var modules = new List<IRequestModule>(14 + config.Modules?.Count ?? 0)
+            var modules = new List<IRequestModule>(15 + config.Modules?.Count ?? 0)
             {
                 new ErrorCatchingModule(),
                 new RequestTransformationModule(config.RequestTransforms),
+                new OperationNameFallbackModule(),
                 new RequestPriorityApplicationModule()
             };
 
@@ -53,7 +54,7 @@ namespace Vostok.Clusterclient.Modules
 
         public static Func<IRequestContext, Task<ClusterResult>> BuildChainDelegate(IList<IRequestModule> modules)
         {
-            Func<IRequestContext, Task<ClusterResult>> result = ctx => { throw new NotSupportedException(); };
+            Func<IRequestContext, Task<ClusterResult>> result = ctx => throw new NotSupportedException();
 
             for (var i = modules.Count - 1; i >= 0; i--)
             {

--- a/Vostok.Core.Tests/ClusterClient/Core/Modules/OperationNameFallbackModule_Tests.cs
+++ b/Vostok.Core.Tests/ClusterClient/Core/Modules/OperationNameFallbackModule_Tests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Vostok.Clusterclient.Model;
+using Vostok.Clusterclient.Modules;
+using Vostok.Flow;
+using Vostok.Tracing;
+
+namespace Vostok.Clusterclient.Core.Modules
+{
+    [TestFixture]
+    internal class OperationNameFallbackModule_Tests
+    {
+        private Request request;
+        private IRequestContext context;
+        private OperationNameFallbackModule module;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            Context.Properties.RemoveProperty(TracingAnnotationNames.Operation);
+
+            request = Request.Get("foo/bar/6D48F4FC-49EF-444E-A974-24E5F00DAF1E/?a=b");
+
+            context = Substitute.For<IRequestContext>();
+            context.Request.Returns(request);
+
+            module = new OperationNameFallbackModule();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Context.Properties.RemoveProperty(TracingAnnotationNames.Operation);
+        }
+
+        [Test]
+        public void Should_set_operation_name_in_context_when_none_was_provided_earlier()
+        {
+            Execute(() => Context.Properties.Current[TracingAnnotationNames.Operation].Should().Be("GET foo/bar/{guid}"));
+        }
+
+        [Test]
+        public void Should_remove_fallback_operation_name_from_context_as_soon_as_request_completes()
+        {
+            Execute(() => {});
+
+            Context.Properties.Current.ContainsKey(TracingAnnotationNames.Operation).Should().BeFalse();
+        }
+
+        [Test]
+        public void Should_not_override_existing_operation_name_in_context()
+        {
+            Context.Properties.SetProperty(TracingAnnotationNames.Operation, "bullshit");
+
+            Execute(() => Context.Properties.Current[TracingAnnotationNames.Operation].Should().Be("bullshit"));
+        }
+
+        private void Execute(Action payload)
+        {
+            var result = new ClusterResult(ClusterResultStatus.Success, new List<ReplicaResult>(), new Response(ResponseCode.Ok), request);
+
+            var resultTask = Task.FromResult(result);
+
+            var moduleTask = module.ExecuteAsync(
+                context,
+                _ =>
+                {
+                    payload();
+                    return resultTask;
+                });
+
+            moduleTask.GetAwaiter().GetResult().Should().BeSameAs(result);
+        }
+    }
+}

--- a/Vostok.Core.Tests/ClusterClient/Core/Modules/RequestModuleChainBuilder_Tests.cs
+++ b/Vostok.Core.Tests/ClusterClient/Core/Modules/RequestModuleChainBuilder_Tests.cs
@@ -103,21 +103,22 @@ namespace Vostok.Clusterclient.Core.Modules
 
             var modules = RequestModuleChainBuilder.BuildChain(configuration, storageProvider);
 
-            modules.Should().HaveCount(13);
+            modules.Should().HaveCount(14);
 
             modules[0].Should().BeOfType<ErrorCatchingModule>();
             modules[1].Should().BeOfType<RequestTransformationModule>();
-            modules[2].Should().BeOfType<RequestPriorityApplicationModule>();
-            modules[3].Should().BeSameAs(module1);
-            modules[4].Should().BeSameAs(module2);
-            modules[5].Should().BeOfType<LoggingModule>();
-            modules[6].Should().BeOfType<ResponseTransformationModule>();
-            modules[7].Should().BeOfType<ErrorCatchingModule>();
-            modules[8].Should().BeOfType<RequestValidationModule>();
-            modules[9].Should().BeOfType<TimeoutValidationModule>();
-            modules[10].Should().BeOfType<RequestRetryModule>();
-            modules[11].Should().BeOfType<AbsoluteUrlSenderModule>();
-            modules[12].Should().BeOfType<RequestExecutionModule>();
+            modules[2].Should().BeOfType<OperationNameFallbackModule>();
+            modules[3].Should().BeOfType<RequestPriorityApplicationModule>();
+            modules[4].Should().BeSameAs(module1);
+            modules[5].Should().BeSameAs(module2);
+            modules[6].Should().BeOfType<LoggingModule>();
+            modules[7].Should().BeOfType<ResponseTransformationModule>();
+            modules[8].Should().BeOfType<ErrorCatchingModule>();
+            modules[9].Should().BeOfType<RequestValidationModule>();
+            modules[10].Should().BeOfType<TimeoutValidationModule>();
+            modules[11].Should().BeOfType<RequestRetryModule>();
+            modules[12].Should().BeOfType<AbsoluteUrlSenderModule>();
+            modules[13].Should().BeOfType<RequestExecutionModule>();
         }
 
         [Test]
@@ -133,21 +134,22 @@ namespace Vostok.Clusterclient.Core.Modules
 
             var modules = RequestModuleChainBuilder.BuildChain(configuration, storageProvider);
 
-            modules.Should().HaveCount(13);
+            modules.Should().HaveCount(14);
 
             modules[0].Should().BeOfType<ErrorCatchingModule>();
             modules[1].Should().BeOfType<RequestTransformationModule>();
-            modules[2].Should().BeOfType<RequestPriorityApplicationModule>();
-            modules[3].Should().BeOfType<LoggingModule>();
-            modules[4].Should().BeOfType<ResponseTransformationModule>();
-            modules[5].Should().BeOfType<ErrorCatchingModule>();
-            modules[6].Should().BeOfType<RequestValidationModule>();
-            modules[7].Should().BeOfType<TimeoutValidationModule>();
-            modules[8].Should().BeOfType<RequestRetryModule>();
-            modules[9].Should().BeOfType<AdaptiveThrottlingModule>();
-            modules[10].Should().BeOfType<ReplicaBudgetingModule>();
-            modules[11].Should().BeOfType<AbsoluteUrlSenderModule>();
-            modules[12].Should().BeOfType<RequestExecutionModule>();
+            modules[2].Should().BeOfType<OperationNameFallbackModule>();
+            modules[3].Should().BeOfType<RequestPriorityApplicationModule>();
+            modules[4].Should().BeOfType<LoggingModule>();
+            modules[5].Should().BeOfType<ResponseTransformationModule>();
+            modules[6].Should().BeOfType<ErrorCatchingModule>();
+            modules[7].Should().BeOfType<RequestValidationModule>();
+            modules[8].Should().BeOfType<TimeoutValidationModule>();
+            modules[9].Should().BeOfType<RequestRetryModule>();
+            modules[10].Should().BeOfType<AdaptiveThrottlingModule>();
+            modules[11].Should().BeOfType<ReplicaBudgetingModule>();
+            modules[12].Should().BeOfType<AbsoluteUrlSenderModule>();
+            modules[13].Should().BeOfType<RequestExecutionModule>();
         }
     }
 }

--- a/Vostok.Core.Tests/Common/Extensions/Uri/UriNormalizationExtensions_Tests.cs
+++ b/Vostok.Core.Tests/Common/Extensions/Uri/UriNormalizationExtensions_Tests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using NUnit.Framework;
 using Vostok.Commons.Extensions.Uri;
 
@@ -31,11 +32,13 @@ namespace Vostok.Common.Extensions.Uri
         [TestCase("http://vostok/message/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2F/process/", "message/{enc}/process")]
         [TestCase("http://vostok/binary/1234567890ABCDEF/process/", "binary/{hex}/process")]
         [TestCase("http://vostok/binary/1234567890abcdef/process/", "binary/{hex}/process")]
-        public void GetOperationName_should_return_normalizedUrl(string urlString, string normalizeUrl)
+        [TestCase("/binary/1234567890abcdef/process/?a=b", "binary/{hex}/process")]
+        [TestCase("binary/1234567890abcdef/process/?a=b", "binary/{hex}/process")]
+        public void GetNormalizedPath_should_return_normalized_path(string urlString, string normalizeUrl)
         {
-            var uri = new System.Uri(urlString);
+            var uri = new System.Uri(urlString, UriKind.RelativeOrAbsolute);
 
-            var actual = uri.GetOperationName();
+            var actual = uri.GetNormalizedPath();
 
             actual.Should().Be(normalizeUrl);
         }

--- a/Vostok.Core/Commons/Extensions/Uri/UriNormalizationExtensions.cs
+++ b/Vostok.Core/Commons/Extensions/Uri/UriNormalizationExtensions.cs
@@ -17,9 +17,15 @@ namespace Vostok.Commons.Extensions.Uri
         private static readonly int[] guidDashPositions = {8, 13, 18, 23};
         private static readonly int[] guidHexPositions = {0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 14, 15, 16, 17, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35};
 
-        public static string GetOperationName(this System.Uri url)
+        public static string GetNormalizedPath(this System.Uri url)
         {
-            return NormalizeString(url.AbsolutePath.Trim('/'));
+            var path = url.IsAbsoluteUri 
+                ? url.AbsolutePath 
+                : url.ToStringWithoutQuery();
+
+            path = path.Trim('/');
+
+            return NormalizeString(path);
         }
 
         public static string Normalize(this System.Uri url)


### PR DESCRIPTION
Этот PR о том же, что и https://github.com/vostok/clusterclient/pull/10, но сделан правильно.
Помимо замеченных багов, в предыдущем было и два других:
1. Модуль вставлялся не в то место в пайплайне (после него могли сработать преобразования запроса, которые запросто способны поменять его URL).
2. Нормализация пути не работала для относительных урлов, а в КК почти все урлы относительные. Это был show-stopper.