### PR TITLE
Logging crashes on null values in current context

### DIFF
--- a/Vostok.Core/Logging/LogEvent.cs
+++ b/Vostok.Core/Logging/LogEvent.cs
@@ -30,7 +30,7 @@ namespace Vostok.Logging
             if (properties.ContainsKey(name))
                 return;
 
-            properties.Add(name, value);
+            properties.Add(name, value ?? "null");
         }
     }
 }


### PR DESCRIPTION
Если в словаре Context.Properties.Current есть значения null, то приложение крэшится с NullReferenceException.